### PR TITLE
Change development server port and project version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "zeroblend",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 10809",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
This commit will change the port of the development server to `10809`, because the default port is already in use by a different service on my own device. Additionally, the project's version has been downgraded from `0.1.0` to `0.0.1` to mark the project's current state as a pre-release. These changes are applicable in `package.json`.